### PR TITLE
V1.2.2

### DIFF
--- a/index.toml
+++ b/index.toml
@@ -640,7 +640,7 @@ metafile = true
 
 [[files]]
 file = "mods/server-translations-api.pw.toml"
-hash = "923fc4c405b1451a21a0085d2bd2a8354a0755cbedf9c6381b03089f774e791a"
+hash = "70b8c27afe995da569ad74b7f4ae53dc441e99aacedfbd304c62d5e931c63e1d"
 metafile = true
 
 [[files]]

--- a/mods/server-translations-api.pw.toml
+++ b/mods/server-translations-api.pw.toml
@@ -3,7 +3,7 @@ filename = "server-translations-api-1.4.12+1.18.2.jar"
 side = "both"
 
 [download]
-url = "https://maven.nucleoid.xyz/fr/catcore/server-translations-api/1.4.12%2B1.18.2/server-translations-api-1.4.12%2B1.18.2.jar"
+url = "https://cdn.jamalam.tech/server-translations-api-1.4.12%2B1.18.2.jar"
 hash-format = "sha1"
 hash = "78e6601818e184bd0fee7e4f50d57b9d09ca323c"
 mode = ""

--- a/pack.toml
+++ b/pack.toml
@@ -1,12 +1,12 @@
 name = "Jamalam's Modpack"
 author = "Jamalam"
-version = "1.2.1"
+version = "1.2.2"
 pack-format = "packwiz:1.1.0"
 
 [index]
 file = "index.toml"
 hash-format = "sha256"
-hash = "a8842e225cf23be8c5f163bd11ee4eb5f1bc7e7030c210ca5d8eb0e0fd381f96"
+hash = "b5728fd69137760db48ca23215287acd8c6e6b41cc514a70b72429feba7ffff4"
 
 [versions]
 minecraft = "1.18.2"


### PR DESCRIPTION
Hotfixes an issue with the Nucleoid maven by rehosting the required files.